### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/_insert.js
+++ b/lib/_insert.js
@@ -1,6 +1,6 @@
 'use strict';
 var utils = require('./utils');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var checkNew = require('./checkNew');
 module.exports = insert;
 

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -1,7 +1,7 @@
 'use strict';
 var load = require('./load');
 var insert = require('./insert');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var utils = require('./utils');
 var Promise = require('bluebird');
 var checkNew = require('./checkNew');

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,7 +1,7 @@
 'use strict';
 var utils = require('./utils');
 var Promise = require('bluebird');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 module.exports = function (self, array) {
   var todo = [load(self, array)];
   var current;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 exports.contains = contains;
 function contains(a, b) {
   var i = -1;

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "node-uuid": "^1.4.1",
     "bluebird": "^2.2.2",
-    "xtend": "^4.0.0",
+    "noms": "0.0.0",
     "stringmap": "^0.2.2",
     "stringset": "^0.2.1",
-    "noms": "0.0.0"
+    "uuid": "^3.0.0",
+    "xtend": "^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.